### PR TITLE
fixed removing children in reversed order

### DIFF
--- a/src/Data/VirtualDOM.hs
+++ b/src/Data/VirtualDOM.hs
@@ -162,7 +162,7 @@ walkChildren api target old new =
     if oldLength > newLength
         then do
             walkIndexes' [0 .. (newLength - 1)] -- walk up to last child of new
-            walkIndexes' [(oldLength - 1) .. newLength] -- delete children backwards from end
+            walkIndexes' (reverse [newLength .. (oldLength - 1)]) -- delete children backwards from end
         else
             walkIndexes' [0 .. (newLength - 1)]
   where


### PR DESCRIPTION
Haskell creates empty list when bounds are given in descending order without step indicator:

```haskell
ghci> [0..5]
[0,1,2,3,4,5]
ghci> [0..0]
[0]
ghci> [5..1]
[]
ghci> [5,4..1]
[5,4,3,2,1]
```

so in a scenario when a new vdom node had fewer children than the old vdom node the code to remove old children was never executed.
