### PR TITLE
Fix event listeners patching

### DIFF
--- a/src/Data/VirtualDOM.hs
+++ b/src/Data/VirtualDOM.hs
@@ -125,10 +125,8 @@ updateProps api target old new =
                 setAttribute api key value target
             (Just _, Nothing) ->
                 removeAttribute api key target
-            -- (Just prev, Just next) ->
-            (Just _, Just next) ->
-                setAttribute api key next target
-                -- when (prev /= next) (setAttribute api key next target) -- TODO skip comparison only for event listeners
+            (Just prev, Just next) ->
+                when (prev /= next) (setAttribute api key next target)
             (Nothing, Nothing) ->
                 return ()
 


### PR DESCRIPTION
Currently event listeners are being attached to nodes only at node creation time, here: https://github.com/theam/haskell-virtualdom/blob/master/src/Data/VirtualDOM.hs#L98

If a node gets patched than event listeners are left intact. For example, if one has a list of tweets, with each tweet having an event listener attached, and event listeners operate on tweets ids, then after replacing the list with a new list with completely different tweets all the DOM nodes will be patched, not re-created, but all the event handlers will still operate on old tweets ids, silently.

This PR fixes that dangerous behavior, but with a small hack. 

To remove an event listener DOM function `removeEventListener` must be called with event type (eg. "click") and a reference to the actual handler function. But event listeners are created dynamically in Haskell FFI code, and it would require some quite complicated stateful code to store all the pointers to all the listeners.

So in this PR pointers to event listener functions are stored in the related DOM node property, and all the event listeners for a given event are removed at once, in quite an ugly way.

While this is less than ideal, it still fixes the main problem - silent business logic errors related to event listeners being called with completely unrelated data.

Maybe even this PR will inspire somebody to come up with better implementation :-)